### PR TITLE
PRIPAD-5148 Allow platform-specific redirect

### DIFF
--- a/server/php/includes/assetdirectory.php
+++ b/server/php/includes/assetdirectory.php
@@ -1,0 +1,153 @@
+<?php
+
+class AssetDirectory {
+  
+  private $_dir;
+  private $_language;
+  
+  public $ipa;
+  public $plist;
+  public $profile;
+  public $apk;
+  public $json;
+  public $note;
+  
+  
+  public function __construct(Directory $dir, $language) {
+      $this->_dir = $dir;
+      $this->_language = $language;
+      $this->parseDirectoryContents();
+  }  
+  
+  private function parseDirectoryContents() {
+      // iOS
+      $this->ipa        = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_IOS_IPA));
+      $this->plist      = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_IOS_PLIST));
+      $this->profile    = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_IOS_PROFILE));
+
+      // Android
+      $this->apk        = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_ANDROID_APK));
+      $this->json       = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_ANDROID_JSON));
+    
+      $this->note = '';
+      // Common
+      if ($this->_language) {
+          $this->note   = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_COMMON_NOTES . '.' . $this->_language));
+      }
+      if (!$this->note) {
+          $this->note   = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_COMMON_NOTES));   // the default language file should not have a language extension, so if en is default, never creaete a .html.en file!
+      }
+      $this->icon       = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_COMMON_ICON));
+      $this->mandatory  = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_VERSION_MANDATORY));    // this file defines if the version is mandatory
+      $this->restrict   = @array_shift(glob($this->_dir->path . '/*' . AppUpdater::FILE_VERSION_RESTRICT));    // this file defines the teams allowed to access this version
+  }
+  
+  
+  public function getApplicationVersions($platform) {
+      $files = array();
+
+        $allVersions = array();
+        
+        if ((!$this->ipa || !$this->plist) && 
+            (!$this->apk || !$this->json)) {
+            // check if any are available in a subdirectory
+            
+            $subDirs = array();
+            if ($handleSub = opendir($this->_dir->path)) {
+                while (($fileSub = readdir($handleSub)) !== false) {
+                    if (!in_array($fileSub, array('.', '..')) && 
+                        is_dir($this->_dir->path . '/'. $fileSub)) {
+                        array_push($subDirs, $fileSub);
+                    }
+                }
+                closedir($handleSub);
+            }
+
+            // Sort the files and display
+            usort($subDirs, array($this, 'sort_versions'));
+            
+            if (count($subDirs) > 0) {
+                foreach ($subDirs as $subDir) {
+                    $subDirectory = dir($this->_dir->path . '/'. $subDir);
+                    $subAssetDir = new AssetDirectory($subDirectory, $this->_language);
+          
+                    if ($subAssetDir->ipa && $subAssetDir->plist && (!$platform || $platform == AppUpdater::PLATFORM_IOS)) {
+                        $version = array();
+                        $version[AppUpdater::FILE_IOS_IPA] = $subAssetDir->ipa;
+                        $version[AppUpdater::FILE_IOS_PLIST] = $subAssetDir->plist;
+                        $version[AppUpdater::FILE_COMMON_NOTES] = $subAssetDir->note;
+                        $version[AppUpdater::FILE_VERSION_RESTRICT] = $subAssetDir->restrict;
+                        $version[AppUpdater::FILE_VERSION_MANDATORY] = $subAssetDir->mandatory;
+                        
+                        // if this is a restricted version, check if the UDID is provided and allowed
+                        if ($subAssetDir->restrict && !$this->checkProtectedVersion($subAssetDir->restrict)) {
+                            continue;
+                        }
+                        
+                        $allVersions[$subDir] = $version;
+                    } else if ($subAssetDir->apk && $subAssetDir->json && (!$platform || $platform == AppUpdater::PLATFORM_ANDROID)) {
+                        $version = array();
+                        $version[AppUpdater::FILE_ANDROID_APK] = $subAssetDir->apk;
+                        $version[AppUpdater::FILE_ANDROID_JSON] = $subAssetDir->json;
+                        $version[AppUpdater::FILE_COMMON_NOTES] = $subAssetDir->note;
+                        $allVersions[$subDir] = $version;
+                    }
+                }
+
+                if (count($allVersions) > 0) {
+                    $files[AppUpdater::VERSIONS_SPECIFIC_DATA] = $allVersions;
+                    $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_IOS_PROFILE] = $subAssetDir->profile;
+                    $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_COMMON_ICON] = $subAssetDir->icon;
+                }
+            }
+        } else {
+            $version = array();
+            if ($this->ipa && $this->plist) {
+                $version[AppUpdater::FILE_IOS_IPA] = $this->ipa;
+                $version[AppUpdater::FILE_IOS_PLIST] = $this->plist;
+                $version[AppUpdater::FILE_COMMON_NOTES] = $this->note;
+                $allVersions[] = $version;
+                $files[AppUpdater::VERSIONS_SPECIFIC_DATA] = $allVersions;
+                $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_IOS_PROFILE] = $this->profile;
+                $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_COMMON_ICON] = $this->icon;
+            } else if ($this->apk && $this->json) {
+                $version[AppUpdater::FILE_ANDROID_APK] = $this->apk;
+                $version[AppUpdater::FILE_ANDROID_JSON] = $this->json;
+                $version[AppUpdater::FILE_COMMON_NOTES] = $this->note;
+                $allVersions[] = $version;
+                $files[AppUpdater::VERSIONS_SPECIFIC_DATA] = $allVersions;
+                $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_COMMON_ICON] = $this->icon;
+            }
+        }
+        
+        return $files;
+  }
+  
+  protected function checkProtectedVersion($restrict) {
+    $allowedTeams = array();
+    foreach (@file($restrict) as $line) {
+        if (preg_match('/^\s*#/', $line)) continue;
+        $items = array_filter(array_map('trim', explode(',', $line)));
+        $allowedTeams = array_merge($allowedTeams, $items);
+    }
+
+    if (!$allowedTeams) return true;
+
+    $udid = Router::arg(AppUpdater::PARAM_2_UDID);
+    if (!$udid) return false;
+    
+    $users = AppUpdater::parseUserList();
+    if (isset($users[$udid])) {
+        return count(array_intersect($users[$udid]['teams'], $allowedTeams)) > 0;
+    }
+    
+    return false;
+  }
+  
+  protected function sort_versions($a, $b) {
+      return version_compare($a, $b, '<');
+  }
+    
+}
+
+?>

--- a/server/php/includes/main.php
+++ b/server/php/includes/main.php
@@ -365,7 +365,7 @@ class AppUpdater
             return;
         }
         
-        $directory = dir($this->appDirectory . $file);
+        $directory = dir($path);
 
         // now check if this directory has the 3 mandatory files
         $device = null;

--- a/server/php/includes/main.php
+++ b/server/php/includes/main.php
@@ -413,26 +413,26 @@ class AppUpdater
         $newApp[self::INDEX_STATS] = array();
 
         if ($ipa) {
-                    // iOS application
-                    $plistDocument = new DOMDocument();
-                    $plistDocument->load($plist);
-                    $parsed_plist = parsePlist($plistDocument);
+            // iOS application
+            $plistDocument = new DOMDocument();
+            $plistDocument->load($plist);
+            $parsed_plist = parsePlist($plistDocument);
 
-                    // now get the application name from the plist
-                    $newApp[self::INDEX_APP]            = $parsed_plist['items'][0]['metadata']['title'];
-                    if (isset($parsed_plist['items'][0]['metadata']['subtitle']) && $parsed_plist['items'][0]['metadata']['subtitle'])
-                        $newApp[self::INDEX_SUBTITLE]   = $parsed_plist['items'][0]['metadata']['subtitle'];
-                    $newApp[self::INDEX_VERSION]        = $parsed_plist['items'][0]['metadata']['bundle-version'];
-                    $newApp[self::INDEX_DATE]           = filectime($ipa);
-                    $newApp[self::INDEX_APPSIZE]        = filesize($ipa);
+            // now get the application name from the plist
+            $newApp[self::INDEX_APP]            = $parsed_plist['items'][0]['metadata']['title'];
+            if (isset($parsed_plist['items'][0]['metadata']['subtitle']) && $parsed_plist['items'][0]['metadata']['subtitle'])
+                $newApp[self::INDEX_SUBTITLE]   = $parsed_plist['items'][0]['metadata']['subtitle'];
+            $newApp[self::INDEX_VERSION]        = $parsed_plist['items'][0]['metadata']['bundle-version'];
+            $newApp[self::INDEX_DATE]           = filectime($ipa);
+            $newApp[self::INDEX_APPSIZE]        = filesize($ipa);
+            
+            if ($profile) {
+                $newApp[self::INDEX_PROFILE]        = $profile;
+                $newApp[self::INDEX_PROFILE_UPDATE] = filectime($profile);
+            }
+            $newApp[self::INDEX_PLATFORM]       = self::APP_PLATFORM_IOS;
                     
-                    if ($profile) {
-                        $newApp[self::INDEX_PROFILE]        = $profile;
-                        $newApp[self::INDEX_PROFILE_UPDATE] = filectime($profile);
-                    }
-                    $newApp[self::INDEX_PLATFORM]       = self::APP_PLATFORM_IOS;
-                    
-                } else if ($apk) {
+        } else if ($apk) {
             // Android Application
             
             // parse the json file
@@ -455,34 +455,34 @@ class AppUpdater
         $filename = $this->appDirectory."stats/".$directory->path;
 
         if (file_exists($filename)) {
-                    $users = self::parseUserList();
+            $users = self::parseUserList();
                 
-                    $lines = @file($filename, FILE_IGNORE_NEW_LINES);
-                    foreach ($lines as $i => $line) {
-                        if (!$line) continue;
+            $lines = @file($filename, FILE_IGNORE_NEW_LINES);
+            foreach ($lines as $i => $line) {
+                if (!$line) continue;
                         
-                        $device = explode(self::STATS_SEPARATOR, $line);
-                        $device[0] = strtolower($device[0]); // need case-insensitive match
-                        $newdevice = array();
-                        $newdevice[self::DEVICE_USER]        = isset($users[$device[0]]) ? $users[$device[0]]['name'] : '-';
-                        $newdevice[self::DEVICE_PLATFORM]    = Helper::mapPlatform(isset($device[1]) ? $device[1] : null);
-                        $newdevice[self::DEVICE_OSVERSION]   = isset($device[2]) ? $device[2] : '';
-                        $newdevice[self::DEVICE_APPVERSION]  = isset($device[3]) ? $device[3] : '';
-                        $newdevice[self::DEVICE_LASTCHECK]   = isset($device[4]) ? $device[4] : '';
-                        $newdevice[self::DEVICE_LANGUAGE]    = isset($device[5]) ? $device[5] : '';
-                        $newdevice[self::DEVICE_INSTALLDATE] = isset($device[6]) ? $device[6] : '';
-                        $newdevice[self::DEVICE_USAGETIME]   = isset($device[7]) ? $device[7] : '';
-                    
-                        $newApp[self::INDEX_STATS][] = $newdevice;
-                    }
+                $device = explode(self::STATS_SEPARATOR, $line);
+                $device[0] = strtolower($device[0]); // need case-insensitive match
+                $newdevice = array();
+                $newdevice[self::DEVICE_USER]        = isset($users[$device[0]]) ? $users[$device[0]]['name'] : '-';
+                $newdevice[self::DEVICE_PLATFORM]    = Helper::mapPlatform(isset($device[1]) ? $device[1] : null);
+                $newdevice[self::DEVICE_OSVERSION]   = isset($device[2]) ? $device[2] : '';
+                $newdevice[self::DEVICE_APPVERSION]  = isset($device[3]) ? $device[3] : '';
+                $newdevice[self::DEVICE_LASTCHECK]   = isset($device[4]) ? $device[4] : '';
+                $newdevice[self::DEVICE_LANGUAGE]    = isset($device[5]) ? $device[5] : '';
+                $newdevice[self::DEVICE_INSTALLDATE] = isset($device[6]) ? $device[6] : '';
+                $newdevice[self::DEVICE_USAGETIME]   = isset($device[7]) ? $device[7] : '';
+            
+                $newApp[self::INDEX_STATS][] = $newdevice;
+            }
                 
-                    // sort by app version
-                    $newApp[self::INDEX_STATS] = Helper::array_orderby($newApp[self::INDEX_STATS], 
-                                                                        self::DEVICE_APPVERSION, SORT_DESC, 
-                                                                        self::DEVICE_OSVERSION, SORT_DESC, 
-                                                                        self::DEVICE_PLATFORM, SORT_ASC, 
-                                                                        self::DEVICE_INSTALLDATE, SORT_DESC, 
-                                                                        self::DEVICE_LASTCHECK, SORT_DESC);
+            // sort by app version
+            $newApp[self::INDEX_STATS] = Helper::array_orderby($newApp[self::INDEX_STATS], 
+                                                                self::DEVICE_APPVERSION, SORT_DESC, 
+                                                                self::DEVICE_OSVERSION, SORT_DESC, 
+                                                                self::DEVICE_PLATFORM, SORT_ASC, 
+                                                                self::DEVICE_INSTALLDATE, SORT_DESC, 
+                                                                self::DEVICE_LASTCHECK, SORT_DESC);
         }
     
         // add it to the array

--- a/server/php/includes/main.php
+++ b/server/php/includes/main.php
@@ -360,6 +360,11 @@ class AppUpdater
         $appBundleIdentifier = $arguments['bundleidentifier'];
         
         $file = join($arguments, "/");
+        $path = $this->appDirectory . $file;
+        if (!file_exists($path)) {
+            return;
+        }
+        
         $directory = dir($this->appDirectory . $file);
 
         // now check if this directory has the 3 mandatory files

--- a/server/php/includes/renderer.php
+++ b/server/php/includes/renderer.php
@@ -62,7 +62,7 @@ class Renderer {
                 $button = new view("button.html");
                 $button->replaceAll(array(
                     "text"  => "Download Application",
-                    "url"   => "{baseurl}" . $app['path']
+                    "url"   => $this->_router->baseURL . $app['path']
                 ));
                 $buttons->append($button);
             }

--- a/server/php/includes/router.php
+++ b/server/php/includes/router.php
@@ -10,6 +10,8 @@ class Router
         '/apps' => '/index',
         '/apps/' => '/index',
         '/apps/:bundleidentifier@^[\w-.]+$' => '/app',
+        '/apps/:bundleidentifier@^[\w-.]+/:variant@.*' => '/app',
+        '/apps/:bundleidentifier@^[\w-.]+/:variant@.*/:version@.*' => '/app',
         '/api/2/apps/:bundleidentifier@^[\w-.]+$' => '/api'
     );
 

--- a/server/php/includes/views/app.html
+++ b/server/php/includes/views/app.html
@@ -1,17 +1,16 @@
 <div id="container" class="container-fluid">
     <div class="row">
-        <div class="col-xs-3">
-            <img class="icon" src="{baseurl}{image}">
-        </div>
-        <div class="col-xs-8">
-            <h2>{title}</h2>
-            <p><b>Version:</b> {version}<br />
+        <img class="icon" src="{baseurl}{image}">
+        <h2>{title}</h2>
+        <p>
+            <b>Version:</b> {version}<br />
             <b>Size:</b> {size}<br />
-            <b>Released:</b> {released}</p>
+            <b>Released:</b> {released}
+        </p>
     
-            {buttons}
+        <br />
+        {buttons}
             
-            {releasenotes}
-        </div>
+        {releasenotes}
     </div>
 </div>

--- a/server/php/includes/views/button.html
+++ b/server/php/includes/views/button.html
@@ -1,1 +1,1 @@
-<a class="button btn btn-success" href="{url}">{text}</a>
+<a class="button btn btn-primary" href="{url}">{text}</a>

--- a/server/php/includes/views/superview.html
+++ b/server/php/includes/views/superview.html
@@ -8,10 +8,10 @@
         <link rel="stylesheet" href="{baseurl}css/overrides.css" type="text/css" media="screen, projection">
         <link rel="alternate" type="application/rss+xml" title="App Updates" href="{baseurl}feed.php" />
     </head>
-    <body>
+    <body class="text-center">
         <div id="container" class="container">
             <h1>Install Apps</h1>
-            <p class='lead'>Visit this page directly from your iPad, iPhone, iPod touch or Android device and you will be able to install an app directly on your device.</p>
+            <p class='lead visible-md visible-lg'>Visit this page directly from your iPad, iPhone, iPod touch or Android device and you will be able to install an app directly on your device.</p>
             <hr />
         <div>
         {content}
@@ -23,8 +23,7 @@
             setTimeout(function () { window.scrollTo(0, 1); }, 2000);
             
             if( ( navigator.userAgent.match( /iPhone/i ) ) ||
-                ( navigator.userAgent.match( /iPod/i ) ) ||
-                ( navigator.userAgent.match( /iPad/i ) )) {
+                ( navigator.userAgent.match( /iP[oa]d/i ) ) ) {
                document.body.classList.add( 'iOS' );
             }
             else if ( navigator.userAgent.match( /Android/i ) ) {

--- a/server/php/public/css/overrides.css
+++ b/server/php/public/css/overrides.css
@@ -5,3 +5,7 @@
 body.iOS #container .icon, body.desktop #container .icon {
     border-radius:20px;
 }
+
+.icon {
+    max-width: 96px;
+}


### PR DESCRIPTION
- Split out some functionality from the `AppUpdater` class into a `AssetDirectory` class, as the former is massive.
- If a directory contains files for Android and iOS it will select the appropriate one for the requesting platform.
