### PR TITLE
PRIPAD-5148 Allow nested starting dir in route

### DIFF
--- a/server/php/includes/assetdirectory.php
+++ b/server/php/includes/assetdirectory.php
@@ -67,10 +67,12 @@ class AssetDirectory {
             });
             
             if (count($subDirs) > 0) {
+                $icon = null;
                 foreach ($subDirs as $subDir) {
-                    $subDirectory = dir($this->_dir->path . "/" . $subDir);
-                    $subAssetDir = new AssetDirectory($subDirectory, $this->_language);
           
+                    $subDirectory = dir($this->_dir->path . $subDir);
+                    $subAssetDir = new AssetDirectory($subDirectory, $this->_language);
+                    
                     if ($subAssetDir->ipa && $subAssetDir->plist && (!$platform || $platform == AppUpdater::PLATFORM_IOS)) {
                         $version = array();
                         $version[AppUpdater::FILE_IOS_IPA] = $subAssetDir->ipa;
@@ -78,6 +80,10 @@ class AssetDirectory {
                         $version[AppUpdater::FILE_COMMON_NOTES] = $subAssetDir->note;
                         $version[AppUpdater::FILE_VERSION_RESTRICT] = $subAssetDir->restrict;
                         $version[AppUpdater::FILE_VERSION_MANDATORY] = $subAssetDir->mandatory;
+                        
+                        if ($icon == null) {
+                            $icon = $subAssetDir->icon;
+                        }
                         
                         // if this is a restricted version, check if the UDID is provided and allowed
                         if ($subAssetDir->restrict && !$this->checkProtectedVersion($subAssetDir->restrict)) {
@@ -91,13 +97,17 @@ class AssetDirectory {
                         $version[AppUpdater::FILE_ANDROID_JSON] = $subAssetDir->json;
                         $version[AppUpdater::FILE_COMMON_NOTES] = $subAssetDir->note;
                         $allVersions[$subDir] = $version;
+                        
+                        if ($icon == null) {
+                            $icon = $subAssetDir->icon;
+                        }
                     }
                 }
         
                 if (count($allVersions) > 0) {
                     $files[AppUpdater::VERSIONS_SPECIFIC_DATA] = $allVersions;
                     $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_IOS_PROFILE] = $subAssetDir->profile;
-                    $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_COMMON_ICON] = $subAssetDir->icon;
+                    $files[AppUpdater::VERSIONS_COMMON_DATA][AppUpdater::FILE_COMMON_ICON] = $icon;
                 }
             }
         } else {

--- a/server/php/includes/main.php
+++ b/server/php/includes/main.php
@@ -345,12 +345,13 @@ class AppUpdater
     {
         $appBundleIdentifier = $arguments['bundleidentifier'];
         
+        if ($appBundleIdentifier == null) return;
+
         $file = join($arguments, "/");
         $path = $this->appDirectory . $file;
-        if (!file_exists($path)) {
-            return;
-        }
         
+        if (!file_exists($path)) return;
+
         $directory = dir($path);
 
         // now check if this directory has the 3 mandatory files

--- a/server/php/includes/router.php
+++ b/server/php/includes/router.php
@@ -6,13 +6,11 @@
 class Router
 {
     static $routes = array(
-        '/' => '/index',
-        '/apps' => '/index',
+        '/apps/(?P<bundleidentifier>[\w/]*?)/?(?P<platform>android|ios)?/?(?P<version>[0-9.]+)?$' => '/app',
+        '/api/2/apps/:bundleidentifier@^[\w-.]+$' => '/api',
         '/apps/' => '/index',
-        '/apps/:bundleidentifier@^[\w-.]+$' => '/app',
-        '/apps/:bundleidentifier@^[\w-.]+/:variant@.*' => '/app',
-        '/apps/:bundleidentifier@^[\w-.]+/:variant@.*/:version@.*' => '/app',
-        '/api/2/apps/:bundleidentifier@^[\w-.]+$' => '/api'
+        '/apps' => '/index',
+        '/' => '/index'
     );
 
     static protected $instance;
@@ -144,59 +142,22 @@ class Router
     
     public function match($url, $route, $info)
     {
-        // Logger::log("Route:\t$route");
-        list($controller, $action) = explode('/', $info);
+        $matches = array();
+        preg_match("/" .  addcslashes($route, "/") . "/", $url, $matches);
+        if (count($matches) == 0) return false;
         
-        $url_exploded = explode('/', $url);
-        $route_exploded = explode('/', $route);
-
-        if (count($url_exploded) != count($route_exploded))
-        {
-            // Logger::log('!!! Length does not match');
-            return false;
-        }
+        $keys = array_filter(array_keys($matches), function ($var) {
+            return !is_numeric($var);
+        });
         
         $arguments = array();
-        
-        $count = count($url_exploded);
-        $i = 0;
-        $is_matching = true;
-        
-        while ($is_matching && $i < $count)
-        {
-            $url_part   = $url_exploded[$i];
-            $route_part = $route_exploded[$i];
-            
-            // special route part?
-            if (strpos($route_part, ':') === 0)
-            {
-                // argument
-                if (!preg_match('/:([\w_]+)(@(.*))?/', $route_part, $matches))
-                {
-                    // Logger::log("!!! Argument $route_part does not match");
-                    return false;
-                }
-                
-                $argument = $matches[1];
-                $value = $url_part;
-                
-                if (!isset($matches[3]) || !preg_match("/{$matches[3]}/u", $value))
-                {
-                    // Logger::log("!!! Argument {$matches[1]} = $value does not match");
-                    return false;
-                }
-                
-                $arguments[$argument] = $value;
-            }
-            elseif ($url_part != $route_part)
-            {
-                // Logger::log("!!! $url_part does not match $route_part");
-                return false;
-            }
-            
-            $i++;
+        foreach ($keys as $key) {
+            $arguments[$key] = $matches[$key];
         }
         
+        // Logger::log("Route:\t$route");
+        list($controller, $action) = explode('/', $info);
+
         // Logger::log("*** Match $controller/$action");
         $this->controller = $controller;
         $this->action     = $action;

--- a/server/php/includes/router.php
+++ b/server/php/includes/router.php
@@ -7,7 +7,7 @@ class Router
 {
     static $routes = array(
         '/apps/(?P<bundleidentifier>[\w/]*?)/?(?P<platform>android|ios)?/?(?P<version>[0-9.]+)?$' => '/app',
-        '/api/2/apps/:bundleidentifier@^[\w-.]+$' => '/api',
+        '/api/2/apps/(?P<bundleidentifier>[\w-.]+)$' => '/api',
         '/apps/' => '/index',
         '/apps' => '/index',
         '/' => '/index'


### PR DESCRIPTION
The routing functionality provided in standard HockeyKit assumes that the setup will be:
`host.com/bundle_id/ios/`. Ideally we shouldn't be tied to starting at `bundle_id`.

By default routes are split by `/` and are then further broken apart in the format of `:key@regex_value`. This prevents any complex routing from taking place. I've swapped the router out for one that uses named regex capture groups instead of the custom key/value matchers. This allows us to nest directories as deep as required, and also requires less code to parse as it uses built in functionality.
