### PR TITLE
Allow ignoring of subdirectories

### DIFF
--- a/server/php/includes/assetdirectory.php
+++ b/server/php/includes/assetdirectory.php
@@ -12,6 +12,13 @@ class AssetDirectory {
     public $json;
     public $note;
     
+    /**
+    These directories won't be searched when traversing
+    down the directory structure. If the user accesses
+    directly these will still function as normal.
+    */
+    private $ignored_subdirectories = array("support");
+    
     
     public function __construct(Directory $dir, $language) {
         $this->_dir = $dir;
@@ -57,7 +64,10 @@ class AssetDirectory {
             foreach($objects as $object) {
                 if ($object->isDir()) {
                     $path = str_replace($this->_dir->path, "", $object->getPathname());
-                    array_push($subDirs, $path);
+                    $subdir = explode("/", $path)[1];
+                    if (!in_array($subdir, $this->ignored_subdirectories)) {
+                        array_push($subDirs, $path);
+                    }
                 }
             }
         

--- a/server/php/includes/router.php
+++ b/server/php/includes/router.php
@@ -6,7 +6,7 @@
 class Router
 {
     static $routes = array(
-        '/apps/(?P<bundleidentifier>[\w/\.-]*?)(?:/(?P<platform>android|ios))?(?:/(?P<version>[0-9.]+))?$' => '/app',
+        '/apps/(?P<bundleidentifier>[\w/\.-]*?)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[0-9.]+))?$' => '/app',
         '/api/2/apps/(?P<bundleidentifier>[\w-.]+)$' => '/api',
         '/apps/' => '/index',
         '/apps' => '/index',


### PR DESCRIPTION
Allow us to specify directories to ignore inside the main directory. If you access these URL's directly they will work, but they won't be scanned when displaying builds further up the URL chain. This allows us to have `support` (enterprise or otherwise) builds stored inside the folder as well as `ios` and `android`
