### PR TITLE
Fix itms links under iOS

### DIFF
--- a/server/php/includes/platforms/ios.php
+++ b/server/php/includes/platforms/ios.php
@@ -24,19 +24,23 @@ class iOSAppUpdater extends AbstractAppUpdater
     protected function download($arguments) {
         $bundleidentifier = $arguments[self::PARAM_2_IDENTIFIER];
         $format           = $arguments[self::PARAM_2_FORMAT];
+
+        $directory = dir($bundleidentifier);
         
-        $files = $this->getApplicationVersions($bundleidentifier, self::PLATFORM_IOS);
+        $files = $this->getApplicationVersions($directory, self::PLATFORM_IOS);
+        
         if (count($files) == 0) {
             Logger::log("no versions found: $bundleidentifier $type");
             return Helper::sendJSONAndExit(self::E_NO_VERSIONS_FOUND);
         }
-
-        $dir = array_shift(array_keys($files[self::VERSIONS_SPECIFIC_DATA]));
+        
+        $keys = array_keys($files[self::VERSIONS_SPECIFIC_DATA]);
+        $dir = array_shift($keys);
         $current = $files[self::VERSIONS_SPECIFIC_DATA][$dir];
         
         if ($format == self::PARAM_2_FORMAT_VALUE_PLIST) // || $type == self::PARAM_1_TYPE_VALUE_APP)
         {
-            $image = $files[self::VERSIONS_COMMON_DATA][self::FILE_COMMON_ICON];
+            $image = $current[self::FILE_COMMON_ICON];
             $file = isset($current[self::FILE_IOS_PLIST]) ? $current[self::FILE_IOS_PLIST] : null;
             
             if (!$file)
@@ -244,7 +248,7 @@ XML;
         }
 
         $profile = $files[self::VERSIONS_COMMON_DATA][self::FILE_IOS_PROFILE];
-        $image   = $files[self::VERSIONS_COMMON_DATA][self::FILE_COMMON_ICON];
+        $image   = $current[self::FILE_COMMON_ICON];
 
         $udid       = Router::arg(self::PARAM_2_UDID);
         $appversion = Router::arg(self::PARAM_2_APP_VERSION) != null ? Router::arg(self::PARAM_2_APP_VERSION) : Router::arg(self::PARAM_1_APP_VERSION);

--- a/server/php/includes/renderer.php
+++ b/server/php/includes/renderer.php
@@ -81,7 +81,14 @@ class Renderer {
             if ($app[AppUpdater::INDEX_PLATFORM] == AppUpdater::APP_PLATFORM_IOS ||
                 $app[AppUpdater::INDEX_PLATFORM] == AppUpdater::APP_PLATFORM_ANDROID) {
                 $button = new view("button.html");
-                $this->_downloadURL = $this->_router->baseURL . $app['path'];
+                
+                if ($app[AppUpdater::INDEX_PLATFORM] == AppUpdater::APP_PLATFORM_IOS) {
+                    $this->_downloadURL = "itms-services://?action=download-manifest&url=" . urlencode($this->_router->baseURL . "api/2/apps/" . $app[AppUpdater::INDEX_DIR] . "?format=plist");
+                }
+                else {
+                    $this->_downloadURL = $this->_router->baseURL . $app['path'];
+                }
+
                 $button->replaceAll(array(
                     "text"  => "Download Application",
                     "url"   => $this->_downloadURL

--- a/server/php/includes/router.php
+++ b/server/php/includes/router.php
@@ -6,8 +6,8 @@
 class Router
 {
     static $routes = array(
-        '/apps/(?P<bundleidentifier>[\w/\.-]*?)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[0-9.]+))?$' => '/app',
-        '/api/2/apps/(?P<bundleidentifier>[\w-.]+)$' => '/api',
+        '^/apps/(?P<bundleidentifier>[\w/\.-]*?)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[0-9.]+))?$' => '/app',
+        '/api/2/apps/(?P<bundleidentifier>[\w-.]+)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[0-9.]+))?' => '/api',
         '/apps/' => '/index',
         '/apps' => '/index',
         '/' => '/index'


### PR DESCRIPTION
Does what it says on the tin. Actually send the `itms-services` link so iOS can download the OTA build.
