### PR TITLE
PRIPAD-5155 Support Android subplatforms

### DIFF
--- a/server/php/includes/assetdirectory.php
+++ b/server/php/includes/assetdirectory.php
@@ -65,7 +65,7 @@ class AssetDirectory {
                 if ($object->isDir()) {
                     $path = str_replace($this->_dir->path, "", $object->getPathname());
                     
-                    $components = explode("/", $path);
+                    $components = explode("/", ltrim($path, "/"));
                     $subdir = $components[0];
                     if (!in_array($subdir, $this->ignored_subdirectories)) {
                         array_push($subDirs, $path);
@@ -105,6 +105,11 @@ class AssetDirectory {
                         $version[AppUpdater::FILE_ANDROID_JSON] = $subAssetDir->json;
                         $version[AppUpdater::FILE_COMMON_NOTES] = $subAssetDir->note;
                         
+                        // Is this a build for a specific android platform?
+                        $matches = array();
+                        if (preg_match("/android\/[0-9\.\/]*(?P<platform>[\w]+)/i", $subAssetDir->_dir->path, $matches)) {
+                            $version[AppUpdater::ANDROID_SUBPLATFORM] = ucfirst($matches["platform"]);
+                        }
 
                         $version[AppUpdater::FILE_COMMON_ICON] = $subAssetDir->icon;
                         $allVersions[$subDir] = $version;

--- a/server/php/includes/renderer.php
+++ b/server/php/includes/renderer.php
@@ -54,7 +54,8 @@ class Renderer {
             
             if ($shouldUseTable) {
                 $this->_superview->replace("prompt", "Click on the icons below to visit the download page for each app.");
-                $content->replace("platform", $app[AppUpdater::INDEX_PLATFORM]);
+                $platform = isset($app[AppUpdater::ANDROID_SUBPLATFORM]) ? $app[AppUpdater::INDEX_PLATFORM] . " (" . $app[AppUpdater::ANDROID_SUBPLATFORM] . ")" : $app[AppUpdater::INDEX_PLATFORM];
+                $content->replace("platform", $platform);
                 $content->replace("download_link", "/apps/" . dirname($app['path']));
                 $this->_content->append($content);
                 continue;

--- a/server/php/includes/views/appstable.html
+++ b/server/php/includes/views/appstable.html
@@ -1,22 +1,14 @@
-
-<head>
-
-   <style>
-    tr.spaceUnder > td
-    {
-        padding-bottom: 15px;
-        font-size:13pt;
-    }
-    </style>
-
-</head>
-
-<table style="width: 100%" cellspacing="10">
-    <tr class="spaceUnder">
-        <td align="left" width="5%"><a href="{download_link}"><img class="icon" width="75" height="75" src="{baseurl}{image}"></a></div></td>
-        <td align="left" width="15%"><a href="{download_link}" style="color: rgb(0,0,0)">{title}</td>
-        <td align="left" width="5%">{platform}</td>
-        <td align="left" width="40%">{version}</td>
-    </tr>
-</table>
-
+<div class="container-fluid app-container">
+    <div class="col-md-6">
+        <div class="container-fluid">
+            <div class="app-text col-md-3 text-left"><a href="{download_link}"><img class="icon" width="75" height="75" src="{baseurl}{image}"></a></div>
+            <div class="app-text col-md-6 text-left"><a class="app-link" href="{download_link}">{title}</a></div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="container-fluid">
+            <div class="app-text col-md-4 text-left">{platform}</div>
+            <div class="app-text col-md-6 text-left">{version}</div>
+        </div>
+    </div>
+</div>

--- a/server/php/public/css/overrides.css
+++ b/server/php/public/css/overrides.css
@@ -9,3 +9,33 @@ body.iOS #container .icon, body.desktop #container .icon {
 .icon {
     max-width: 96px;
 }
+
+.app-container, .app-container div {
+    padding:0;
+    margin:0;
+}
+
+.app-container {
+    margin-bottom:15px;
+}
+
+.app-text {
+    font-size:13pt;
+}
+
+.app-text a {
+    color: rgb(0,0,0);
+}
+
+.iOS .app-text, .android .app-text {
+    text-align:center !important;
+}
+
+.desktop .app-link {
+    height: 70px;
+    line-height: 70px;
+}
+
+#container h2 {
+    margin-top: 15px;
+}


### PR DESCRIPTION
... So you can see versions of apps for a specific android subplatform. Files stored against /android/1.1/samsung, /android/1.1/play etc.

I've also made Donal's appstable responsive so it'll reflow for devices.
