### PR TITLE
PRIPAD-5320 Support non-numeric version numbers

### DIFF
--- a/server/php/includes/router.php
+++ b/server/php/includes/router.php
@@ -6,8 +6,8 @@
 class Router
 {
     static $routes = array(
-        '^/apps/(?P<bundleidentifier>[\w/\.-]*?)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[0-9.]+))?$' => '/app',
-        '^/api/2/apps/(?P<bundleidentifier>[\w/\.-]*)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[0-9.]+))?' => '/api',
+        '^/apps/(?P<bundleidentifier>[\w/\.-]*?)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[\w\d.]+))?$' => '/app',
+        '^/api/2/apps/(?P<bundleidentifier>[\w/\.-]*?)(?:/(?P<platform>android|ios|support))?(?:/(?P<version>[\w\d.]+))?$' => '/api',
         '/api/upload' => '/upload',
         '/apps/' => '/index',
         '/apps' => '/index',

--- a/server/php/includes/upload.php
+++ b/server/php/includes/upload.php
@@ -132,7 +132,29 @@ class Upload {
     }
     
     private function path() {
-        return $this->sanitisePath($this->_baseDirectory, $this->_metadata["location"]);
+        return $this->sanitisePath($this->_baseDirectory, $this->location());
+    }
+    
+    private function location() {
+        $disallowedCharacterPattern = "([^\w\d.\/]+)";
+        $patterns = array(
+            /**
+             Filter out any trailing characters we don't want,
+             and replace them with nothing.
+            */
+            $disallowedCharacterPattern . '$'  => "",
+            /**
+             Change any instances of disallowed characters into
+             a dot separator.
+            */
+            $disallowedCharacterPattern        => "."
+        );
+        
+        $location = $this->_metadata["location"];
+        foreach ($patterns as $pattern => $replacement) {
+          $location = preg_replace("/$pattern/", $replacement, $location);
+        }
+        return $location;
     }
     
     private function removePackageFromDirectory($path) {
@@ -156,7 +178,7 @@ class Upload {
     private function publishAppPackage($file, $location = null, $format = "%sapps/%s") {
         $name = preg_replace("/[^0-9a-z\.A-Z]+/", "_",  $file["name"]);
         move_uploaded_file($file["tmp_name"], "{$this->path()}/" . $location . $name);
-        return sprintf($format, $this->_baseURL, $this->_metadata["location"], $name);
+        return sprintf($format, $this->_baseURL, $this->location(), $name);
     }
     
     private function sanitisePath($baseDirectory, $location) {


### PR DESCRIPTION
Support non-numeric version numbers, i.e. `2.7.2b2`.
If you put in a version number that contains disallowed characters (any character that isn't in the set `\w\d.` - word character (including underscore), decimal, dot) it will flatten the version to something we can represent in the URL. So if you had a version as `2.7.2b2 (74)`, the version will become `2.7.2b2.74`.
