### PR TITLE
Serve correct package & json file

### DIFF
--- a/server/php/includes/platforms/android.php
+++ b/server/php/includes/platforms/android.php
@@ -26,7 +26,13 @@ class AndroidAppUpdater extends AbstractAppUpdater
         $bundleidentifier = $arguments[self::PARAM_2_IDENTIFIER];
         $format           = $arguments[self::PARAM_2_FORMAT];
         
-        $files = $this->getApplicationVersions($bundleidentifier, self::PLATFORM_ANDROID);
+        
+        $path = $arguments;
+        // Remove the format from the array
+        array_pop($path);
+        $directory = dir(join($path, "/"));
+        
+        $files = $this->getApplicationVersions($directory, self::PLATFORM_ANDROID);
         if (count($files) == 0) {
             Logger::log("no versions found: $bundleidentifier $type");
             return Helper::sendJSONAndExit(self::E_NO_VERSIONS_FOUND);

--- a/server/php/includes/platforms/ios.php
+++ b/server/php/includes/platforms/ios.php
@@ -25,7 +25,10 @@ class iOSAppUpdater extends AbstractAppUpdater
         $bundleidentifier = $arguments[self::PARAM_2_IDENTIFIER];
         $format           = $arguments[self::PARAM_2_FORMAT];
 
-        $directory = dir($bundleidentifier);
+        $path = $arguments;
+        // Remove the format from the array
+        array_pop($path);
+        $directory = dir(join($path, "/"));
         
         $files = $this->getApplicationVersions($directory, self::PLATFORM_IOS);
         


### PR DESCRIPTION
The file serving code was still only using the `bundleidentifier` to identify the IPA / APK to serve. Fine if you've got one package in the directory, or want the latest version, but otherwise you will _always_ get the latest version available.
